### PR TITLE
Port: SourceEvent

### DIFF
--- a/gherkin/elixir/lib/gherkin/media.ex
+++ b/gherkin/elixir/lib/gherkin/media.ex
@@ -1,0 +1,6 @@
+defmodule Gherkin.Media do
+  @type t :: %__MODULE__{encoding: String.t(), type: String.t()}
+
+  @enforce_keys [:encoding, :type]
+  defstruct @enforce_keys
+end

--- a/gherkin/elixir/lib/gherkin/source_event.ex
+++ b/gherkin/elixir/lib/gherkin/source_event.ex
@@ -1,0 +1,25 @@
+defmodule Gherkin.SourceEvent do
+  alias Gherkin.Media
+
+  @type t :: %__MODULE__{
+          data: File.io_device(),
+          media: Media.t(),
+          type: String.t(),
+          uri: Path.t()
+        }
+
+  @enforce_keys [:data, :media, :type, :uri]
+  defstruct @enforce_keys
+
+  @spec stream([Path.t()]) :: Enumerable.t()
+  def stream(paths), do: Stream.map(paths, &event/1)
+
+  @spec event(Path.t()) :: t
+  defp event(path),
+    do: %__MODULE__{
+      data: File.open!(path, [:read, :utf8]),
+      media: %Media{encoding: "utf-8", type: "text/x.cucumber.gherkin+plain"},
+      type: "source",
+      uri: path
+    }
+end


### PR DESCRIPTION
Why
---

Build a struct or pseudo-object (module that wraps an agent) in Elixir for every object in the Ruby implementation until Elixir implementation passes Cucumber’s acceptance tests

How
---

* Port SourceEvent
* Create Media struct