### PR TITLE
Convert AST node from pseudo-object to struct

### DIFF
--- a/gherkin/elixir/lib/gherkin/source_event.ex
+++ b/gherkin/elixir/lib/gherkin/source_event.ex
@@ -12,7 +12,7 @@ defmodule Gherkin.SourceEvent do
   defstruct @enforce_keys
 
   @spec stream([Path.t()]) :: Enumerable.t()
-  def stream(paths), do: Stream.map(paths, &event/1)
+  def stream(paths) when is_list(paths), do: Stream.map(paths, &event/1)
 
   @spec event(Path.t()) :: t
   defp event(path),


### PR DESCRIPTION
Why
---

The functionality was self-contained and straightforward enough to allow easy conversion to an immutable data structure

How
---

* Replace agent process and query functions with struct
* Update AST builder to use AST node struct