### PR TITLE
Port: TokenFormatterBuilder

### DIFF
--- a/gherkin/elixir/lib/gherkin/ast_node.ex
+++ b/gherkin/elixir/lib/gherkin/ast_node.ex
@@ -1,4 +1,4 @@
-defmodule Gherkin.AST.Node do
+defmodule Gherkin.ASTNode do
   @type rule_type ::
           :Background
           | :DataTable

--- a/gherkin/elixir/lib/gherkin/builder.ex
+++ b/gherkin/elixir/lib/gherkin/builder.ex
@@ -1,0 +1,10 @@
+defmodule Gherkin.Builder do
+  alias Gherkin.{ASTNode, Token}
+
+  @type t :: struct
+
+  @callback build(t, Token.t()) :: t
+  @callback end_rule(t, ASTNode.rule_type()) :: t
+  @callback get_result(t) :: term
+  @callback start_rule(t, ASTNode.rule_type()) :: t
+end

--- a/gherkin/elixir/lib/gherkin/errors.ex
+++ b/gherkin/elixir/lib/gherkin/errors.ex
@@ -8,7 +8,7 @@ defmodule Gherkin.ErrorMessage do
     do: "(#{location.line}:#{location.column || 0}): #{message}"
 end
 
-defmodule Gherkin.AST.BuilderError do
+defmodule Gherkin.ASTBuilderError do
   alias Gherkin.ErrorMessage
 
   defexception [:location, :message]

--- a/gherkin/elixir/lib/gherkin/token_formatter_builder.ex
+++ b/gherkin/elixir/lib/gherkin/token_formatter_builder.ex
@@ -1,0 +1,51 @@
+defmodule Gherkin.TokenFormatterBuilder do
+  alias Gherkin.{Builder, Token}
+
+  @behaviour Builder
+
+  @type t :: %__MODULE__{tokens_text: iolist}
+
+  defstruct tokens_text: []
+
+  @impl Builder
+  def build(%__MODULE__{} = builder, %Token{} = token),
+    do: Map.update!(builder, :tokens_text, &[&1, format_token(token), ?\n])
+
+  @spec format_token(Token.t()) :: iodata
+  defp format_token(token) do
+    if Token.eof?(token) do
+      "EOF"
+    else
+      [
+        ?(,
+        token.location.line,
+        ?:,
+        token.location.column,
+        ?),
+        token.matched_type,
+        ?:,
+        token.matched_keyword,
+        ?/,
+        token.matched_text,
+        ?/,
+        format_items(token.matched_items)
+      ]
+    end
+  end
+
+  @spec format_items([TableCell.t()] | [Tag.t()]) :: iolist
+  defp format_items(items),
+    do:
+      items
+      |> Stream.map(&[&1.column, ?:, &1.text])
+      |> Enum.intersperse(?,)
+
+  @impl Builder
+  def end_rule(%__MODULE__{} = builder, rule_type) when is_atom(rule_type), do: builder
+
+  @impl Builder
+  def get_result(%__MODULE__{tokens_text: tokens_text}), do: IO.iodata_to_binary(tokens_text)
+
+  @impl Builder
+  def start_rule(%__MODULE__{} = builder, rule_type) when is_atom(rule_type), do: builder
+end


### PR DESCRIPTION
Why
---

Build a struct or pseudo-object (module that wraps an agent) in Elixir for every object in the Ruby implementation until Elixir implementation passes Cucumber’s acceptance tests

How
---

* Port TokenFormatterBuilder module
* Extract Builder module
* Merge AST namespace into module names